### PR TITLE
Retry on rate exceeded error.

### DIFF
--- a/src/docker-compose-cli.js
+++ b/src/docker-compose-cli.js
@@ -39,7 +39,7 @@ const pull = async (fileName) => {
     await composeCommand(fileName, 'pull');
   } catch (err) {
     if (isRateExceededError(err)) {
-      return await pull(fileName);
+      return pull(fileName);
     }
     throw err;
   }

--- a/src/docker-compose-cli.js
+++ b/src/docker-compose-cli.js
@@ -43,7 +43,7 @@ const pull = async (fileName) => {
     }
     throw err;
   }
-}
+};
 
 const up = (fileNames) => composeCommand(fileNames, 'up -d --remove-orphans');
 

--- a/src/docker-compose-cli.js
+++ b/src/docker-compose-cli.js
@@ -34,12 +34,14 @@ const composeCommand = (filePaths, ...params) => {
   });
 };
 
-const pull = async (fileName) => {
+const pull = async (fileName, retry = 100) => {
   try {
     await composeCommand(fileName, 'pull');
   } catch (err) {
-    if (isRateExceededError(err)) {
-      return pull(fileName);
+    if (isRateExceededError(err) && retry > 0) {
+      console.warn('Pull rate limit exceeded. Retrying.');
+      await new Promise(r => setTimeout(r, 1000));
+      return pull(fileName, --retry);
     }
     throw err;
   }

--- a/test/unit/docker-compose-cli.spec.js
+++ b/test/unit/docker-compose-cli.spec.js
@@ -182,6 +182,7 @@ describe('docker-compose cli', () => {
       expect(console.log.calledWith('things')).to.equal(true);
     });
 
+    // https://docs.aws.amazon.com/AmazonECR/latest/userguide/common-errors.html
     it('should retry on rate exceeded error', async () => {
       const filename = 'path/to/file.yml';
       const result = dockerComposeCli.pull(filename);
@@ -199,6 +200,11 @@ describe('docker-compose cli', () => {
       await Promise.resolve();
 
       expect(childProcess.spawn.callCount).to.equal(3);
+      spawnedProcess.events.error({ message: 'Unknown: Rate exceeded' });
+
+      await Promise.resolve();
+
+      expect(childProcess.spawn.callCount).to.equal(4);
       spawnedProcess.events.exit(0);
 
       await result;

--- a/test/unit/docker-compose-cli.spec.js
+++ b/test/unit/docker-compose-cli.spec.js
@@ -182,6 +182,28 @@ describe('docker-compose cli', () => {
       expect(console.log.calledWith('things')).to.equal(true);
     });
 
+    it('should retry on rate exceeded error', async () => {
+      const filename = 'path/to/file.yml';
+      const result = dockerComposeCli.pull(filename);
+
+      expect(childProcess.spawn.callCount).to.equal(1);
+      spawnedProcess.stderrCb('toomanyrequests: Rate exceeded');
+      spawnedProcess.events.exit(1);
+
+      await Promise.resolve();
+
+      expect(childProcess.spawn.callCount).to.equal(2);
+      spawnedProcess.stderrCb('toomanyrequests: Rate exceeded');
+      spawnedProcess.events.exit(1);
+
+      await Promise.resolve();
+
+      expect(childProcess.spawn.callCount).to.equal(3);
+      spawnedProcess.events.exit(0);
+
+      await result;
+    });
+
     it('should reject on error', async () => {
       const filename = 'path/to/filename.yml';
       const result = dockerComposeCli.pull(filename);

--- a/test/unit/docker-compose-cli.spec.js
+++ b/test/unit/docker-compose-cli.spec.js
@@ -1,10 +1,13 @@
 const childProcess = require('child_process');
 const dockerComposeCli = require('../../src/docker-compose-cli');
 
+let clock;
+
 describe('docker-compose cli', () => {
   let spawnedProcess;
 
   beforeEach(() => {
+    clock = sinon.useFakeTimers();
     spawnedProcess = { };
     sinon.stub(childProcess, 'spawn').returns(spawnedProcess);
     spawnedProcess.events = {};
@@ -16,6 +19,10 @@ describe('docker-compose cli', () => {
     };
     spawnedProcess.on = sinon.stub().callsFake((event, cb) => spawnedProcess.events[event] = cb);
     process.env = { CHT_COMPOSE_PROJECT_NAME: 'cht' };
+  });
+
+  afterEach(() => {
+    clock.restore();
   });
 
   describe('validate', () => {
@@ -192,22 +199,44 @@ describe('docker-compose cli', () => {
       spawnedProcess.events.exit(1);
 
       await Promise.resolve();
+      clock.tick(1000);
+      await Promise.resolve();
 
       expect(childProcess.spawn.callCount).to.equal(2);
       spawnedProcess.stderrCb('toomanyrequests: Rate exceeded');
       spawnedProcess.events.exit(1);
 
       await Promise.resolve();
+      clock.tick(1000);
+      await Promise.resolve();
 
       expect(childProcess.spawn.callCount).to.equal(3);
       spawnedProcess.events.error({ message: 'Unknown: Rate exceeded' });
 
+      await Promise.resolve();
+      clock.tick(1000);
       await Promise.resolve();
 
       expect(childProcess.spawn.callCount).to.equal(4);
       spawnedProcess.events.exit(0);
 
       await result;
+    });
+
+    it('should throw error after 100 rate exceeded retries', async () => {
+      const filename = 'path/to/file.yml';
+      const result = dockerComposeCli.pull(filename);
+
+      for (let i = 0; i <= 100; i++) {
+        expect(childProcess.spawn.callCount).to.equal(i + 1);
+        spawnedProcess.stderrCb('toomanyrequests: Rate exceeded');
+        spawnedProcess.events.exit(1);
+
+        await Promise.resolve();
+        clock.tick(1000);
+        await Promise.resolve();
+      }
+      await expect(result).to.be.rejectedWith('toomanyrequests: Rate exceeded');
     });
 
     it('should reject on error', async () => {


### PR DESCRIPTION
According to the documentation (https://docs.aws.amazon.com/AmazonECR/latest/userguide/common-errors.html), the error that we're supposed to get is `TOOMANYREQUESTS: Rate exceeded` or Unknown: Rate exceeded (for older docker versions). 

![image](https://user-images.githubusercontent.com/35681649/196935772-9e78f71e-a877-4851-a2dd-3bcd1fdcb0bb.png)

When the error message matches `Rate exceeded`, retry the `pull`. 
#20