### PR TITLE
build multiplatform cht-upgrade-service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Setup Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -3,6 +3,7 @@ const buildTime = new Date().getTime();
 const path = require('path');
 
 const { spawn } = require('child_process');
+const BUILD_PLATFORMS = ['linux/amd64', 'linux/arm64/v8'];
 
 const {
   ECR_REPO,
@@ -66,19 +67,19 @@ const dockerCommand = (args) => {
     const dockerfilePath = path.join(__dirname, '..', '..', 'Dockerfile');
     const tagFlags = tags.map(tag => ['-t', tag]).flat();
     const dockerBuildParams = [
+      'buildx',
       'build',
+      '--provenance=false',
+      '--platform='+ BUILD_PLATFORMS.join(','),
       '-f',
       dockerfilePath,
       ...tagFlags,
+      '--push',
       '.'
     ];
 
     await dockerCommand(dockerBuildParams);
-    for (const tag of tags) {
-      await dockerCommand(['push', tag]);
-    }
-
   } catch (err) {
-    console.error('Error while publishing docker image', err);
+    console.error('Error while building or publishing docker image', err);
   }
 })();


### PR DESCRIPTION
In medic/cht-core#8841, we made all cht-core images multi-platform supported. However, upgrade service was not worked on at that point. This pr makes cht-upgrade-service multi-platform and supports same multi-platform platforms supported by cht-core. 

Fixes: #36 