### PR TITLE
chore: bumps version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medic/cht-upgrade-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@medic/cht-upgrade-service",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "body-parser": "^1.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/cht-upgrade-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Docker bridge to upgrade cht service containers",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
 to see if tag gets published